### PR TITLE
also ensure lua build cross-compiles

### DIFF
--- a/makefile
+++ b/makefile
@@ -54,8 +54,9 @@ MYLDFLAGS= $(LOCAL) -Wl,-E
 MYLIBS= -ldl -lreadline -lhistory -lncurses
 
 
-ifndef CC
 CC=gcc
+ifdef BUILDROOT_CC
+CC=$(BUILDROOT_CC)
 endif
 
 CFLAGS= -Wall -O2 $(MYCFLAGS)

--- a/makefile
+++ b/makefile
@@ -54,7 +54,10 @@ MYLDFLAGS= $(LOCAL) -Wl,-E
 MYLIBS= -ldl -lreadline -lhistory -lncurses
 
 
-CC= gcc
+ifndef CC
+CC=gcc
+endif
+
 CFLAGS= -Wall -O2 $(MYCFLAGS)
 AR= ar rcu
 RANLIB= ranlib


### PR DESCRIPTION
This jerry-rig should let me pass a different compiler than gcc via the CC environment variable